### PR TITLE
Check that "-k" isn't already included before adding it

### DIFF
--- a/bin/RNAseq_process_data.sh
+++ b/bin/RNAseq_process_data.sh
@@ -486,7 +486,8 @@ do
                 echo "can't create non-aggregate directory"
             fi
 
-            if [[ $no_new_txps != "NULL" ]]
+            # add '-k' flag if needed and not already included
+            if [[ $no_new_txps != "NULL" ]] && [[ "$more_flags" != *" -k"* ]]
             then
                 more_flags="$more_flags -k"
             fi


### PR DESCRIPTION
I tested this with my job having 45 samples and now each "RNAseq.sh" command produced has a single "-k" flag instead of _N_ "-k" flags for the _N_th sample. (i.e. the last sample out of 45 samples previously had 45 "-k" flags).
